### PR TITLE
feat: Color 에셋, Onboarding view 추가 .. :)

### DIFF
--- a/ggokkok/ggokkok.xcodeproj/project.pbxproj
+++ b/ggokkok/ggokkok.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		B27CAE572A739BC00010D0FE /* EditInjectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27CAE562A739BC00010D0FE /* EditInjectionView.swift */; };
 		B27CAE5A2A739BF80010D0FE /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27CAE592A739BF80010D0FE /* SettingView.swift */; };
 		B27CAE5C2A739E670010D0FE /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27CAE5B2A739E670010D0FE /* Date+.swift */; };
+		B27CAE5E2A73B49E0010D0FE /* CustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27CAE5D2A73B49E0010D0FE /* CustomColor.swift */; };
+		B27CAE602A73B5B50010D0FE /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27CAE5F2A73B5B50010D0FE /* Color+.swift */; };
+		B27CAE632A73B6F80010D0FE /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27CAE622A73B6F80010D0FE /* OnboardingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +67,9 @@
 		B27CAE562A739BC00010D0FE /* EditInjectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditInjectionView.swift; sourceTree = "<group>"; };
 		B27CAE592A739BF80010D0FE /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
 		B27CAE5B2A739E670010D0FE /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		B27CAE5D2A73B49E0010D0FE /* CustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomColor.swift; sourceTree = "<group>"; };
+		B27CAE5F2A73B5B50010D0FE /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
+		B27CAE622A73B6F80010D0FE /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,6 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				B268F9992A7391FF0083A87A /* MainView.swift */,
+				B27CAE612A73B6120010D0FE /* OnboardingView */,
 				B27CAE452A7399C30010D0FE /* RecommendView */,
 				B27CAE4A2A739A800010D0FE /* HistoryView */,
 				B27CAE502A739B8D0010D0FE /* CreateEditView */,
@@ -184,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				B27CAE5B2A739E670010D0FE /* Date+.swift */,
+				B27CAE5F2A73B5B50010D0FE /* Color+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -191,6 +199,7 @@
 		B268F9CB2A7392890083A87A /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				B27CAE5D2A73B49E0010D0FE /* CustomColor.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -259,6 +268,14 @@
 				B27CAE592A739BF80010D0FE /* SettingView.swift */,
 			);
 			path = SettingView;
+			sourceTree = "<group>";
+		};
+		B27CAE612A73B6120010D0FE /* OnboardingView */ = {
+			isa = PBXGroup;
+			children = (
+				B27CAE622A73B6F80010D0FE /* OnboardingView.swift */,
+			);
+			path = OnboardingView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -394,9 +411,12 @@
 				B27CAE4C2A739A920010D0FE /* HistoryView.swift in Sources */,
 				B27CAE442A73986D0010D0FE /* CoredataExampleView.swift in Sources */,
 				B27CAE492A7399E60010D0FE /* RecommendView.swift in Sources */,
+				B27CAE632A73B6F80010D0FE /* OnboardingView.swift in Sources */,
 				B27CAE5C2A739E670010D0FE /* Date+.swift in Sources */,
+				B27CAE5E2A73B49E0010D0FE /* CustomColor.swift in Sources */,
 				B27CAE4F2A739B570010D0FE /* InjectionModel.swift in Sources */,
 				B268F9A12A7392000083A87A /* Persistence.swift in Sources */,
+				B27CAE602A73B5B50010D0FE /* Color+.swift in Sources */,
 				B27CAE552A739BB00010D0FE /* CreateInjectionView.swift in Sources */,
 				B27CAE572A739BC00010D0FE /* EditInjectionView.swift in Sources */,
 				B268F9A42A7392000083A87A /* GgokKok.xcdatamodeld in Sources */,

--- a/ggokkok/ggokkok/Assets.xcassets/Color/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/black.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/black.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x21",
+          "green" : "0x21",
+          "red" : "0x21"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/blue100.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/blue100.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xF6",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/blue200.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/blue200.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xEE",
+          "red" : "0xE4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/blue300.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/blue300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFE",
+          "green" : "0x87",
+          "red" : "0x59"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/gray300.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/gray300.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.749",
+          "green" : "0.702",
+          "red" : "0.702"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/gray400.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/gray400.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA1",
+          "green" : "0xA1",
+          "red" : "0xAB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/gray500.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/gray500.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x81",
+          "green" : "0x81",
+          "red" : "0x8C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/longActing.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/longActing.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x0A",
+          "green" : "0x68",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/mixedActing.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/mixedActing.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x47",
+          "red" : "0x97"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/rapidActing.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/rapidActing.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x95",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/red.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/red.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x30",
+          "green" : "0x3B",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Assets.xcassets/Color/white.colorset/Contents.json
+++ b/ggokkok/ggokkok/Assets.xcassets/Color/white.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggokkok/ggokkok/Common/CustomColor.swift
+++ b/ggokkok/ggokkok/Common/CustomColor.swift
@@ -1,0 +1,23 @@
+//
+//  Color.swift
+//  GgokKok
+//
+//  Created by sei on 2023/07/28.
+//
+
+import Foundation
+
+enum CustomColor: String {
+    case black
+    case blue100
+    case blue200
+    case blue300
+    case gray300
+    case gray400
+    case gray500
+    case longActing
+    case mixedActing
+    case rapidActing
+    case red
+    case white
+}

--- a/ggokkok/ggokkok/Extension/Color+.swift
+++ b/ggokkok/ggokkok/Extension/Color+.swift
@@ -1,0 +1,23 @@
+//
+//  Color+.swift
+//  GgokKok
+//
+//  Created by sei on 2023/07/28.
+//
+
+import SwiftUI
+
+extension Color {
+    static var black: Color { Color(CustomColor.black.rawValue) }
+    static var blue100: Color { Color(CustomColor.blue100.rawValue) }
+    static var blue200: Color { Color(CustomColor.blue200.rawValue) }
+    static var blue300: Color { Color(CustomColor.blue300.rawValue) }
+    static var gray300: Color { Color(CustomColor.gray300.rawValue) }
+    static var gray400: Color { Color(CustomColor.gray400.rawValue) }
+    static var gray500: Color { Color(CustomColor.gray500.rawValue) }
+    static var longActing: Color { Color(CustomColor.longActing.rawValue) }
+    static var mixedActing: Color { Color(CustomColor.mixedActing.rawValue) }
+    static var rapidActing: Color { Color(CustomColor.rapidActing.rawValue) }
+    static var red: Color { Color(CustomColor.red.rawValue) }
+    static var white: Color { Color(CustomColor.white.rawValue) }
+}

--- a/ggokkok/ggokkok/View/MainView.swift
+++ b/ggokkok/ggokkok/View/MainView.swift
@@ -24,7 +24,7 @@ struct MainView: View {
 
 extension MainView {
     private enum Views: String, CaseIterable {
-//        case coredataExampleView
+        case onboardingView
         case recommendView
         case historyView
         case editInjectionView
@@ -33,8 +33,8 @@ extension MainView {
 
         var view: some View {
             switch self {
-//            case .coredataExampleView:
-//                return AnyView(CoredataExampleView())
+            case .onboardingView:
+                return AnyView(OnboardingView())
             case .recommendView:
                 return AnyView(RecommendView())
             case .historyView:

--- a/ggokkok/ggokkok/View/OnboardingView/OnboardingView.swift
+++ b/ggokkok/ggokkok/View/OnboardingView/OnboardingView.swift
@@ -1,0 +1,20 @@
+//
+//  OnboardingView.swift
+//  GgokKok
+//
+//  Created by sei on 2023/07/28.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    var body: some View {
+        Text("OnboardingView")
+    }
+}
+
+struct OnboardingView_Previews: PreviewProvider {
+    static var previews: some View {
+        OnboardingView()
+    }
+}


### PR DESCRIPTION
# Description
Color Asset 관련 작업을 했습니다.

직전에 OnboardingView를 누락해서 이를 추가했습니다.

# Key Changes
- [x] Color
    - [x] Color Assets에 추가
        - [ ] dark모드 지원
    - [x] CustomColor Enum 추가
    - [x] Color Extension 추가
- [x] OnboardingView 추가

현재 main은 각 뷰를 보기 위한 메인입니다.
