### PR TITLE
주사부위표 마지막 번호 바뀐값 화면에서 업데이트 안되는 버그 픽스

### DIFF
--- a/ggokkok/ggokkok/View/OnboardingView/OnboardingView.swift
+++ b/ggokkok/ggokkok/View/OnboardingView/OnboardingView.swift
@@ -17,7 +17,6 @@ struct OnboardingView: View {
     init(isFirstLaunching: Binding<Bool>, viewModel: OnboardingViewModel) {
         self._isFirstLaunching = isFirstLaunching
         self.viewModel = viewModel
-
         _lastSite = State(initialValue: viewModel.lastSiteNumber == 0 ? "" : viewModel.lastSiteNumber.description)
     }
 
@@ -40,6 +39,9 @@ struct OnboardingView: View {
         .contentShape(Rectangle())
         .onTapGesture {
             isFocused = false
+        }
+        .onAppear {
+            lastSite = viewModel.lastSiteNumber.description
         }
     }
 
@@ -66,7 +68,7 @@ struct OnboardingView: View {
 
     var button: some View {
         Button {
-            viewModel.setLastSiteNumber(Int(lastSite) ?? 31)
+            viewModel.lastSiteNumber = Int(lastSite) ?? 31
             isFocused = false
             if isFirstLaunching {
                 isFirstLaunching = false

--- a/ggokkok/ggokkok/ViewModel/OnboardingViewModel.swift
+++ b/ggokkok/ggokkok/ViewModel/OnboardingViewModel.swift
@@ -9,13 +9,13 @@ import Foundation
 
 class OnboardingViewModel: ObservableObject {
     static let udLastSiteNumber = UserDefaultsKey.lastSiteNumber.rawValue
-    @Published var lastSiteNumber: Int
-
-    init() {
-        lastSiteNumber = UserDefaults.standard.integer(forKey: OnboardingViewModel.udLastSiteNumber)
-    }
-
-    func setLastSiteNumber(_ number: Int) {
-        UserDefaults.standard.set(number, forKey: Self.udLastSiteNumber)
+    var lastSiteNumber: Int {
+        get {
+            print("hehe", UserDefaults.standard.integer(forKey: OnboardingViewModel.udLastSiteNumber))
+            return UserDefaults.standard.integer(forKey: OnboardingViewModel.udLastSiteNumber)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Self.udLastSiteNumber)
+        }
     }
 }


### PR DESCRIPTION
# Description
설정 페이지의 "주사부위표 마지막 번호" 화면에서
숫자값을 변경한뒤 뒤로가기 후 다시 돌아오면 바뀐값 반영 안됨